### PR TITLE
Implement serialization and deserialization for file dict

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/usage/starburst_trino_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/starburst_trino_usage.py
@@ -254,7 +254,6 @@ class TrinoUsageSource(Source):
                     AggregatedDataset(
                         bucket_start_time=floored_ts,
                         resource=resource,
-                        user_email_pattern=self.config.user_email_pattern,
                     ),
                 )
 
@@ -269,6 +268,7 @@ class TrinoUsageSource(Source):
                     username,
                     event.query,
                     metadata.columns,
+                    user_email_pattern=self.config.user_email_pattern,
                 )
         return datasets
 

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
@@ -2,7 +2,7 @@ import collections
 import dataclasses
 import logging
 from datetime import datetime
-from typing import Callable, ClassVar, Counter, Generic, List, Optional, TypeVar
+from typing import Callable, Counter, Generic, List, Optional, TypeVar
 
 import pydantic
 from pydantic.fields import Field

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -1,7 +1,22 @@
 import collections
 import sqlite3
 import tempfile
-from typing import Generic, Iterator, MutableMapping, Optional, OrderedDict, TypeVar
+from typing import (
+    Callable,
+    Generic,
+    Iterator,
+    List,
+    MutableMapping,
+    Optional,
+    OrderedDict,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
+
+# https://docs.python.org/3/library/sqlite3.html#sqlite-and-python-types
+SqliteValue = Union[int, float, str, bytes, None]
 
 _VT = TypeVar("_VT")
 
@@ -10,21 +25,31 @@ class FileBackedDict(MutableMapping[str, _VT], Generic[_VT]):
     """A dictionary that stores its data in a temporary SQLite database.
 
     This is useful for storing large amounts of data that don't fit in memory.
+
+    For performance, implements an in-memory LRU cache using an OrderedDict,
+    and sets a generous journal size limit.
     """
+
+    serializer: Callable[[_VT], SqliteValue]
+    deserializer: Callable[[SqliteValue], _VT]
 
     _cache_max_size: int
     _cache_eviction_batch_size: int
     _filename: str
-    _conn: sqlite3.Connection
 
+    _conn: sqlite3.Connection
     _active_object_cache: OrderedDict[str, _VT]
 
     def __init__(
         self,
+        serializer: Callable[[_VT], SqliteValue],
+        deserializer: Callable[[SqliteValue], _VT],
         filename: Optional[str] = None,
         cache_max_size: int = 2000,
         cache_eviction_batch_size: int = 200,
     ):
+        self._serializer = serializer
+        self._deserializer = deserializer
         self._cache_max_size = cache_max_size
         self._cache_eviction_batch_size = cache_eviction_batch_size
         self._filename = filename or tempfile.mktemp()
@@ -61,10 +86,10 @@ class FileBackedDict(MutableMapping[str, _VT], Generic[_VT]):
             self._prune_cache(num_items_to_prune)
 
     def _prune_cache(self, num_items_to_prune: int) -> None:
-        items_to_write = []
+        items_to_write: List[Tuple[str, SqliteValue]] = []
         for _ in range(num_items_to_prune):
             key, value = self._active_object_cache.popitem(last=False)
-            items_to_write.append((key, value))
+            items_to_write.append((key, self._serializer(value)))
 
         self._conn.executemany(
             "INSERT OR REPLACE INTO data (key, value) VALUES (?, ?)", items_to_write
@@ -79,23 +104,28 @@ class FileBackedDict(MutableMapping[str, _VT], Generic[_VT]):
             return self._active_object_cache[key]
 
         cursor = self._conn.execute("SELECT value FROM data WHERE key = ?", (key,))
-        result = cursor.fetchone()
+        result: Sequence[SqliteValue] = cursor.fetchone()
         if result is None:
             raise KeyError(key)
 
-        self._add_to_cache(key, result[0])
-        return result[0]
+        deserialized_result = self._deserializer(result[0])
+        self._add_to_cache(key, deserialized_result)
+        return deserialized_result
 
     def __setitem__(self, key: str, value: _VT) -> None:
         self._add_to_cache(key, value)
 
     def __delitem__(self, key: str) -> None:
-        self[key]  # raise KeyError if key doesn't exist
-
+        in_cache = False
         if key in self._active_object_cache:
             del self._active_object_cache[key]
+            in_cache = True
 
-        self._conn.execute("DELETE FROM data WHERE key = ?", (key,))
+        n_deleted = self._conn.execute(
+            "DELETE FROM data WHERE key = ?", (key,)
+        ).rowcount
+        if not in_cache and not n_deleted:
+            raise KeyError(key)
 
     def __iter__(self) -> Iterator[str]:
         cursor = self._conn.execute("SELECT key FROM data")
@@ -124,3 +154,6 @@ class FileBackedDict(MutableMapping[str, _VT], Generic[_VT]):
 
     def close(self) -> None:
         self._conn.close()
+
+    def __del__(self) -> None:
+        self.close()

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -2,6 +2,7 @@ import collections
 import sqlite3
 import tempfile
 from typing import (
+    Any,
     Callable,
     Generic,
     Iterator,
@@ -31,7 +32,7 @@ class FileBackedDict(MutableMapping[str, _VT], Generic[_VT]):
     """
 
     serializer: Callable[[_VT], SqliteValue]
-    deserializer: Callable[[SqliteValue], _VT]
+    deserializer: Callable[[Any], _VT]
 
     _cache_max_size: int
     _cache_eviction_batch_size: int
@@ -43,7 +44,7 @@ class FileBackedDict(MutableMapping[str, _VT], Generic[_VT]):
     def __init__(
         self,
         serializer: Callable[[_VT], SqliteValue],
-        deserializer: Callable[[SqliteValue], _VT],
+        deserializer: Callable[[Any], _VT],
         filename: Optional[str] = None,
         cache_max_size: int = 2000,
         cache_eviction_batch_size: int = 200,

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
@@ -1,7 +1,7 @@
 import json
 from collections import Counter
-from dataclasses import dataclass, asdict
-from typing import Dict, List
+from dataclasses import asdict, dataclass
+from typing import Dict
 
 import pytest
 
@@ -85,7 +85,7 @@ def test_file_dict_serialization():
         y: Dict[Label, float]
 
         def to_dict(self) -> Dict:
-            d = {"x": self.x}
+            d: Dict = {"x": self.x}
             str_y = {json.dumps(asdict(k)): v for k, v in self.y.items()}
             d["y"] = json.dumps(str_y)
             return d
@@ -119,10 +119,10 @@ def test_file_dict_serialization():
         serializer=serialize,
         deserializer=deserialize,
         cache_max_size=0,
-        cache_eviction_batch_size=0
+        cache_eviction_batch_size=0,
     )
-    first = Main(3, {Label("one", 1): .1, Label("two", 2): .2})
-    second = Main(-100, {Label("z", 26): .26})
+    first = Main(3, {Label("one", 1): 0.1, Label("two", 2): 0.2})
+    second = Main(-100, {Label("z", 26): 0.26})
 
     cache["first"] = first
     cache["second"] = second


### PR DESCRIPTION
Doing the large-pr in acryldata flow, but in your personal branch.

I opted to make serializer and deserializer required arguments, because adding defaults as json.dumps and json.loads respectively would add extra overhead for basic `FileBackedDict[str]` or `FileBackedDict[int]` objects, when the identify function would be sufficient. I don't think it's too onerous to have to specify your serializer and deserializer, even if it's just the identity function or json functions, and in general something the user should be thinking about when they're using `FileBackedDict`

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
